### PR TITLE
Fixes + Improvements

### DIFF
--- a/near-tell-secrets-contract/assembly/index.ts
+++ b/near-tell-secrets-contract/assembly/index.ts
@@ -1,6 +1,10 @@
-import { Secret, listedSecret } from "./model";
-import { ContractPromiseBatch, context } from "near-sdk-as";
+import {Secret, listedSecret, userReactionStorage, UserReaction} from "./model";
+import {ContractPromiseBatch, context, u128, PersistentMap, logging} from "near-sdk-as";
 
+/**
+ * Add a new secret
+ * @param secret Secret object with details related to new secret
+ */
 export function addSecret(secret: Secret): void {
   let storedSecret = listedSecret.get(secret.id);
   if (storedSecret !== null) {
@@ -9,43 +13,126 @@ export function addSecret(secret: Secret): void {
   listedSecret.set(secret.id, Secret.fromPayload(secret));
 }
 
+/**
+ * Get the details of a given secret
+ * @param id ID of the secret
+ * @return Secret object if it presents with the given ID. Otherwise, null
+ */
 export function getSecret(id: string): Secret | null {
   return listedSecret.get(id);
 }
 
+/**
+ * Returns all secrets in the mapping
+ * @return Secrets Array
+ */
 export function getSecrets(): Secret[] {
   return listedSecret.values();
 }
 
+/**
+ * Gift NEAR to the secret owner of the given secret
+ * @param secretId ID of the secret
+ * @param amount Amount of the NEAR token which would like to donate
+ */
 export function giftOwner(secretId: string, amount: string): void {
   const secret = getSecret(secretId);
   if (secret == null) {
     throw new Error("secret not found");
   }
 
+  if(secret.owner == context.sender.toString()){
+    throw new Error("Cannot gift to own secrets")
+  }
+
   if (amount.toString() != context.attachedDeposit.toString()) {
     throw new Error("attached deposit should equal to the secret's price");
   }
+
   ContractPromiseBatch.create(secret.owner).transfer(context.attachedDeposit);
-  listedSecret.set(secret.id, secret);
 }
 
+/**
+ * Put a like to a given secret
+ * @param secretId ID of the secret
+ */
 export function likeSecret(secretId: string): void {
   const secret = getSecret(secretId);
   if (secret == null) {
     throw new Error("secret not found");
   }
-  secret.owner = context.sender;
-  secret.likes++;
+
+  if(secret.owner == context.sender.toString()){
+    throw new Error("You cannot put likes to own secrets")
+  }
+
+  let userReactions = userReactionStorage.get(context.sender);
+
+  if(userReactions == null){
+    userReactions = UserReaction.init();
+  }
+
+  if(userReactions.likes.includes(secretId)){
+    throw new Error("You have already liked the secret")
+  }
+
+  if(userReactions.disLikes.includes(secretId)){
+    secret.addLike(true);
+
+    let dislikeIndex = userReactions.disLikes.indexOf(secretId);
+    userReactions.disLikes.splice(dislikeIndex, 1);
+  } else {
+    secret.addLike();
+  }
+  userReactions.likes.push(secretId);
+
   listedSecret.set(secret.id, secret);
+  userReactionStorage.set(context.sender, userReactions);
 }
 
+/**
+ * Put a dislike to a given secret
+ * @param secretId ID of the secret
+ */
 export function dislikeSecret(secretId: string): void {
   const secret = getSecret(secretId);
   if (secret == null) {
     throw new Error("secret not found");
   }
-  secret.owner = context.sender;
-  secret.dislikes++;
+
+  if(secret.owner == context.sender.toString()){
+    throw new Error("You cannot put dislikes to own secrets")
+  }
+
+  let userReactions = userReactionStorage.get(context.sender);
+
+  if(userReactions == null){
+    userReactions = UserReaction.init();
+  }
+
+  if(userReactions.disLikes.includes(secretId)){
+    throw new Error("You have already disliked the secret")
+  }
+
+  if(userReactions.likes.includes(secretId)){
+    secret.addDislike(true);
+
+    let likeIndex = userReactions.likes.indexOf(secretId);
+    userReactions.likes.splice(likeIndex, 1);
+  } else {
+    secret.addDislike();
+  }
+  userReactions.disLikes.push(secretId);
+
   listedSecret.set(secret.id, secret);
+  userReactionStorage.set(context.sender, userReactions);
+}
+
+
+/**
+ * Get the details of provided user's reactions to secrets
+ * @return User Reaction object if it presents for the provided account ID. Otherwise, null
+ */
+export function getUserReactions(accountId : string): UserReaction | null {
+  return userReactionStorage.get(accountId);
 }

--- a/near-tell-secrets-contract/assembly/index.ts
+++ b/near-tell-secrets-contract/assembly/index.ts
@@ -1,5 +1,5 @@
-import {Secret, listedSecret, userReactionStorage, UserReaction} from "./model";
-import {ContractPromiseBatch, context, u128, PersistentMap, logging} from "near-sdk-as";
+import { Secret, listedSecret, userReactionStorage, UserReaction } from "./model";
+import { ContractPromiseBatch, context } from "near-sdk-as";
 
 /**
  * Add a new secret

--- a/near-tell-secrets-contract/assembly/model.ts
+++ b/near-tell-secrets-contract/assembly/model.ts
@@ -1,12 +1,12 @@
-import { PersistentUnorderedMap, u128, context } from "near-sdk-as";
+import { PersistentUnorderedMap, u128, context, PersistentMap } from "near-sdk-as";
 
 @nearBindgen
 export class Secret {
   id: string;
   owner: string;
   secretText: string;
-  likes: i8;
-  dislikes: i8;
+  likes: u32;
+  dislikes: u32;
 
   public static fromPayload(payload: Secret): Secret {
     const secret = new Secret();
@@ -14,11 +14,41 @@ export class Secret {
     secret.secretText = payload.secretText;
     secret.owner = context.sender;
     secret.likes = 0;
+    secret.dislikes = 0;
     return secret;
+  }
+
+  public addLike(alreadyDisliked: boolean = false) : void {
+    this.likes++;
+    if(alreadyDisliked){
+      this.dislikes--;
+    }
+  }
+
+  public addDislike(alreadyLiked: boolean = false) : void {
+    this.dislikes++;
+    if(alreadyLiked){
+      this.likes--;
+    }
   }
 
 }
 
-export const listedSecret = new PersistentUnorderedMap<string, Secret>(
-  "secret"
-);
+export const listedSecret = new PersistentUnorderedMap<string, Secret>("secret");
+
+
+@nearBindgen
+export class UserReaction {
+  likes : string[];
+  disLikes: string[];
+
+  public static init() : UserReaction {
+    const userReaction = new UserReaction();
+    userReaction.likes = [];
+    userReaction.disLikes = [];
+
+    return userReaction;
+  }
+}
+
+export const userReactionStorage = new PersistentUnorderedMap<string, UserReaction>("USER_REACTION");

--- a/near-tell-secrets-contract/assembly/model.ts
+++ b/near-tell-secrets-contract/assembly/model.ts
@@ -1,4 +1,4 @@
-import { PersistentUnorderedMap, u128, context, PersistentMap } from "near-sdk-as";
+import { PersistentUnorderedMap, context } from "near-sdk-as";
 
 @nearBindgen
 export class Secret {


### PR DESCRIPTION
## Changes and Fixes

1. Changed the `likes` and `dislikes` attributes type from `Secret` model to `u32` from `i8`. Reason is i8 type refers to signed integers that are used to store both negative and positive values while u32 is an unsigned integer that is used to store only positive values. Since we don't have any negative values, its type should be `u32`. Further info can be found here (https://learning-rust.github.io/docs/a8.primitive_data_types.html#u8-u16-u32-u64-u128)
2. Added another model called `UserReaction`. This has two attributes called likes and dislikes which are used to store the Ids of the secrets.
3. Added another state called `userReactionStorage` which is used to store `UserReaction` objects against user IDs. So that we can keep track of the user reactions to the secrets.
4. Added `addLike` method to the Secret model. It has a parameter called `alreadyDisliked` with a default value set to `false`. So if the `alreadyDisliked` is true, it means that the user who is trying to put a like has already put a dislike in the past. In that case, the `dislikes` count is reduced by 1 while adding a like.
5. Added `addDislike` method to the Secret model. It has a parameter called `alreadyLiked` with a default value set to `false`. So if the `alreadyLiked` is true, it means that the user who is trying to put a dislike has already put a like in the past. In that case, the `likes` count is reduced by 1 while adding a dislike.
6. Added a function named `getUserReactions` which can be used to get the details of the user reactions by providing a user id. So that we can the values returned by them to disable the like or dislike buttons if the user has already put them.
7. Added functionality to use one reaction per user for a particular secret. If the user has already put a dislike while he is trying to put a like, that dislike will be removed. If the user has already put a like while he is trying to put a dislike, that like will be removed. 
8. Added checks to see if the user has already put a like while adding a like or, a dislike while adding a dislike. If any of them comes `true`, it throws an error.
9. Added checks to see if the user is trying to gift NEAR tokens for his own secrets. If it is `true`, it will throw an error.
10. Added comments to the functions with the `@param `and `@returns` details.